### PR TITLE
BUGFIX: DBD-SQLite run test disable

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -636,8 +636,9 @@ function build {
                 cd ..
                 if [ $PERL_MINOR_VER -ge 16 ]; then
                    build_module DBD-SQLite-1.34_01 "" 0
-                fi
-                build_module DBD-SQLite-1.34_01
+                else
+		   build_module DBD-SQLite-1.34_01
+		fi
             fi
             
             ;;


### PR DESCRIPTION
This fixes a bug introduced in a5fc339932dd0c05bab8f81ee3f1dfa113636934, wherein the DBD-SQLite module build command is run twice. Once without tests, and once with.